### PR TITLE
Require Jetpack's custom autoloader and update composer.lock

### DIFF
--- a/client-example.php
+++ b/client-example.php
@@ -39,7 +39,7 @@ if ( ! defined( 'WPINC' ) ) {
  */
 define( 'CLIENT_EXAMPLE_VERSION', '1.0.0' );
 
-require_once dirname( __FILE__ ) . '/vendor/autoload.php';
+require_once plugin_dir_path( __FILE__ ) . '/vendor/autoload_packages.php';
 
 /**
  * The code that runs during plugin activation.

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
+		"automattic/jetpack-autoloader": "dev-master",
         "automattic/jetpack-connection": "dev-master",
         "automattic/jetpack-tracking": "dev-master"
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,56 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bdb5f53f5c8dcd3a8ac3b92501f08f73",
+    "content-hash": "1dbebc67544bc765905729379e0656b0",
     "packages": [
+        {
+            "name": "automattic/jetpack-autoloader",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-autoloader.git",
+                "reference": "efa1cec37282cf60efaf57724ae2532c7c21bf94"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/efa1cec37282cf60efaf57724ae2532c7c21bf94",
+                "reference": "efa1cec37282cf60efaf57724ae2532c7c21bf94",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Automattic\\Jetpack\\Autoloader\\CustomAutoloaderPlugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Automattic\\Jetpack\\Autoloader\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Creates a custom autoloader for a plugin or theme.",
+            "time": "2019-11-25T12:37:57+00:00"
+        },
         {
             "name": "automattic/jetpack-connection",
             "version": "dev-master",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-connection.git",
-                "reference": "73c314c949b0eca52f4dfec0d996bce6ac6e9006"
+                "reference": "5348680ad171cf7e6bdb2de511ac37e8e6db9d16"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-connection/zipball/73c314c949b0eca52f4dfec0d996bce6ac6e9006",
-                "reference": "73c314c949b0eca52f4dfec0d996bce6ac6e9006",
+                "url": "https://api.github.com/repos/Automattic/jetpack-connection/zipball/5348680ad171cf7e6bdb2de511ac37e8e6db9d16",
+                "reference": "5348680ad171cf7e6bdb2de511ac37e8e6db9d16",
                 "shasum": ""
             },
             "require": {
@@ -44,7 +80,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Everything needed to connect to the Jetpack infrastructure",
-            "time": "2019-11-15T16:04:27+00:00"
+            "time": "2019-11-25T13:53:28+00:00"
         },
         {
             "name": "automattic/jetpack-constants",
@@ -249,6 +285,7 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "automattic/jetpack-autoloader": 20,
         "automattic/jetpack-connection": 20,
         "automattic/jetpack-tracking": 20
     },


### PR DESCRIPTION
Add Jetpack's custom autoloader package to `composer.json` and require the `autoload_packages.php` file. Also update `composer.lock`.

To test, run `composer install` and verify that the `jetpack-autoloader` package was installed.