### PR TITLE
Added the "Connect in Place" mechanism.

### DIFF
--- a/admin/class-client-example-admin.php
+++ b/admin/class-client-example-admin.php
@@ -65,8 +65,6 @@ class Client_Example_Admin {
 				return wp_generate_password( 32, false );
 			};
 		} );
-
-		add_filter( 'jetpack_use_iframe_authorization_flow', '__return_true' );
 	}
 
 	/**

--- a/admin/class-client-example-admin.php
+++ b/admin/class-client-example-admin.php
@@ -65,6 +65,27 @@ class Client_Example_Admin {
 				return wp_generate_password( 32, false );
 			};
 		} );
+
+		add_filter( 'jetpack_api_url', array( $this, 'filter_connect_api_iframe_url' ), 10, 2 );
+
+	}
+
+	/**
+	 * Filters the API URL that is used for connect requests. The method
+	 * intercepts only the authorize URL and replaces it with another if needed.
+	 *
+	 * @param String $api_url the default redirect API URL used by the package.
+	 * @param String $relative_url the path of the URL that's being used.
+	 * @return String the modified URL.
+	 */
+	public function filter_connect_api_iframe_url( $api_url, $relative_url ) {
+
+		// Short-circuit on anything that is not related to connect requests.
+		if ( 'authorize' !== $relative_url ) {
+			return $api_url;
+		}
+
+		return $this->manager->api_url( 'authorize_iframe' );
 	}
 
 	/**
@@ -126,7 +147,8 @@ class Client_Example_Admin {
 		 */
 
 		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/client-example-admin.js', array( 'jquery' ), $this->version, false );
-
+		wp_enqueue_script( 'jetpack-iframe-embed', '//s0.wp.com/wp-content/mu-plugins/jetpack-iframe-embed/jetpack-iframe-embed.js', array( 'jquery' ), $ver );
+		wp_localize_script( 'jetpack-iframe-embed', '_previewSite', array( 'siteURL' => get_site_url() ) );
 	}
 
 	/**

--- a/admin/class-client-example-admin.php
+++ b/admin/class-client-example-admin.php
@@ -65,6 +65,8 @@ class Client_Example_Admin {
 				return wp_generate_password( 32, false );
 			};
 		} );
+
+		add_filter( 'jetpack_use_iframe_authorization_flow', '__return_true' );
 	}
 
 	/**

--- a/admin/class-client-example-admin.php
+++ b/admin/class-client-example-admin.php
@@ -147,8 +147,6 @@ class Client_Example_Admin {
 		 */
 
 		wp_enqueue_script( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'js/client-example-admin.js', array( 'jquery' ), $this->version, false );
-		wp_enqueue_script( 'jetpack-iframe-embed', '//s0.wp.com/wp-content/mu-plugins/jetpack-iframe-embed/jetpack-iframe-embed.js', array( 'jquery' ), $ver );
-		wp_localize_script( 'jetpack-iframe-embed', '_previewSite', array( 'siteURL' => get_site_url() ) );
 	}
 
 	/**

--- a/admin/class-client-example-admin.php
+++ b/admin/class-client-example-admin.php
@@ -65,27 +65,6 @@ class Client_Example_Admin {
 				return wp_generate_password( 32, false );
 			};
 		} );
-
-		add_filter( 'jetpack_api_url', array( $this, 'filter_connect_api_iframe_url' ), 10, 2 );
-
-	}
-
-	/**
-	 * Filters the API URL that is used for connect requests. The method
-	 * intercepts only the authorize URL and replaces it with another if needed.
-	 *
-	 * @param String $api_url the default redirect API URL used by the package.
-	 * @param String $relative_url the path of the URL that's being used.
-	 * @return String the modified URL.
-	 */
-	public function filter_connect_api_iframe_url( $api_url, $relative_url ) {
-
-		// Short-circuit on anything that is not related to connect requests.
-		if ( 'authorize' !== $relative_url ) {
-			return $api_url;
-		}
-
-		return $this->manager->api_url( 'authorize_iframe' );
 	}
 
 	/**

--- a/admin/partials/client-example-admin-display.php
+++ b/admin/partials/client-example-admin-display.php
@@ -14,7 +14,9 @@
 
 $user_token = $this->manager->get_access_token( get_current_user_id() );
 $blog_token = $this->manager->get_access_token();
+add_filter( 'jetpack_use_iframe_authorization_flow', '__return_true' );
 $auth_url = $this->manager->get_authorization_url( null, admin_url( '?page=client-example' ) );
+remove_filter( 'jetpack_use_iframe_authorization_flow', '__return_true' );
 ?>
 
 <!-- This file should primarily consist of HTML with a little bit of PHP. -->

--- a/admin/partials/client-example-admin-display.php
+++ b/admin/partials/client-example-admin-display.php
@@ -14,7 +14,7 @@
 
 $token = $this->manager->get_access_token( get_current_user_id() );
 $blog_token = $this->manager->get_access_token();
-
+$auth_url = $this->manager->get_authorization_url( null, admin_url( '?page=client-example' ) );
 ?>
 
 <!-- This file should primarily consist of HTML with a little bit of PHP. -->
@@ -72,4 +72,14 @@ print_r( $token ? $token : 'The current user is not connected' );
 								<p>Even though Jetpack is not installed on your site, the dump below should display the blog_token for your site if you have pressed the Register button. </p>
 <pre>
 <?php print_r( get_option( 'jetpack_private_options', array() ) ); ?>
+</pre>
+
+<iframe class="jp-jetpack-connect__iframe" /></iframe>
+<script type="application/javascript">
+jQuery( function( $ ) {
+	var authorize_url = <?php echo wp_json_encode( $auth_url ); ?>;
+	$( '.jp-jetpack-connect__iframe' ).attr( 'src', authorize_url );
+} );
+</script>
+		 <pre>
 </pre>

--- a/admin/partials/client-example-admin-display.php
+++ b/admin/partials/client-example-admin-display.php
@@ -108,7 +108,8 @@ remove_filter( 'jetpack_use_iframe_authorization_flow', '__return_true' );
 
 <script type="application/javascript">
 jQuery( function( $ ) {
-	var authorize_url = <?php echo wp_json_encode( $auth_url ); ?>;
+
+	var authorize_url = decodeURIComponent( '<?php echo rawurlencode( (string) $auth_url ); ?>' );
 	$( '.jp-jetpack-connect__iframe' ).attr( 'src', authorize_url );
 
 	window.addEventListener('message', (event) => {

--- a/composer.lock
+++ b/composer.lock
@@ -75,12 +75,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-connection.git",
-                "reference": "e9e898ca3acb174a418637cac69355d6aad89762"
+                "reference": "e90e8192a1c47337301620bf597acd98db21a8ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-connection/zipball/e9e898ca3acb174a418637cac69355d6aad89762",
-                "reference": "e9e898ca3acb174a418637cac69355d6aad89762",
+                "url": "https://api.github.com/repos/Automattic/jetpack-connection/zipball/e90e8192a1c47337301620bf597acd98db21a8ea",
+                "reference": "e90e8192a1c47337301620bf597acd98db21a8ea",
                 "shasum": ""
             },
             "require": {
@@ -107,7 +107,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Everything needed to connect to the Jetpack infrastructure",
-            "time": "2020-01-27T11:20:58+00:00"
+            "time": "2020-02-12T05:23:16+00:00"
         },
         {
             "name": "automattic/jetpack-constants",

--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-autoloader.git",
-                "reference": "231d2a76af6aed1e695ee3248ab8a2e428b729c9"
+                "reference": "3cb0ad8496d04a648435ebee7c2a652c80eaf550"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/231d2a76af6aed1e695ee3248ab8a2e428b729c9",
-                "reference": "231d2a76af6aed1e695ee3248ab8a2e428b729c9",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/3cb0ad8496d04a648435ebee7c2a652c80eaf550",
+                "reference": "3cb0ad8496d04a648435ebee7c2a652c80eaf550",
                 "shasum": ""
             },
             "require": {
@@ -40,7 +40,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
-            "time": "2020-01-10T17:12:39+00:00"
+            "time": "2020-01-22T17:49:03+00:00"
         },
         {
             "name": "automattic/jetpack-config",
@@ -48,12 +48,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-config.git",
-                "reference": "20690256ad0560972c3130f283a6727efccdd04f"
+                "reference": "df7cfce4231fb50e8cd433a6ccf52e99a269c16c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-config/zipball/20690256ad0560972c3130f283a6727efccdd04f",
-                "reference": "20690256ad0560972c3130f283a6727efccdd04f",
+                "url": "https://api.github.com/repos/Automattic/jetpack-config/zipball/df7cfce4231fb50e8cd433a6ccf52e99a269c16c",
+                "reference": "df7cfce4231fb50e8cd433a6ccf52e99a269c16c",
                 "shasum": ""
             },
             "type": "library",
@@ -67,7 +67,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Jetpack configuration package that initializes other packages and configures Jetpack's functionality. Can be used as a base for all variants of Jetpack package usage.",
-            "time": "2020-01-20T12:47:08+00:00"
+            "time": "2020-01-21T22:42:22+00:00"
         },
         {
             "name": "automattic/jetpack-connection",
@@ -75,12 +75,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-connection.git",
-                "reference": "1347e12dbd380c064c47831dc560186b678f4c03"
+                "reference": "e9e898ca3acb174a418637cac69355d6aad89762"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-connection/zipball/1347e12dbd380c064c47831dc560186b678f4c03",
-                "reference": "1347e12dbd380c064c47831dc560186b678f4c03",
+                "url": "https://api.github.com/repos/Automattic/jetpack-connection/zipball/e9e898ca3acb174a418637cac69355d6aad89762",
+                "reference": "e9e898ca3acb174a418637cac69355d6aad89762",
                 "shasum": ""
             },
             "require": {
@@ -107,7 +107,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Everything needed to connect to the Jetpack infrastructure",
-            "time": "2020-01-20T12:47:08+00:00"
+            "time": "2020-01-27T11:20:58+00:00"
         },
         {
             "name": "automattic/jetpack-constants",
@@ -210,16 +210,16 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-status.git",
-                "reference": "0fa0a1b135db9e14a598324c4d283482176888c4"
+                "reference": "c688b03859381e66164c821971e851408a5e232a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-status/zipball/0fa0a1b135db9e14a598324c4d283482176888c4",
-                "reference": "0fa0a1b135db9e14a598324c4d283482176888c4",
+                "url": "https://api.github.com/repos/Automattic/jetpack-status/zipball/c688b03859381e66164c821971e851408a5e232a",
+                "reference": "c688b03859381e66164c821971e851408a5e232a",
                 "shasum": ""
             },
             "require-dev": {
-                "brain/monkey": "^2.4",
+                "brain/monkey": "2.4.0",
                 "php-mock/php-mock": "^2.1",
                 "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
             },
@@ -234,7 +234,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Used to retrieve information about the current status of Jetpack and the site overall.",
-            "time": "2020-01-14T16:51:42+00:00"
+            "time": "2020-01-27T11:04:11+00:00"
         },
         {
             "name": "automattic/jetpack-terms-of-service",


### PR DESCRIPTION
This is a WIP.

This PR is a minimal POC for connecting without leaving the page. It implements the same URL that Jetpack uses for the "Connect in Place", but so far omits all bells and whistles.

Already working:
* A user token is added to the site when you click "Approve" in the iframe.

Need to address:
- [x] The iframe looks terrible.
- [x] The iframe does not refresh, redirect, or do anything after clicking the button.
- [x] The code doesn't check whether the site is already registered, and it should - the iframe should only appear on a registered site because it is a second step in the connection process.
- [x] The iframe is placed wherever I felt like.
- [x] The code uses `wp_json_encode`, which is considered unsafe: p7H4VZ-2cf-p2.
- [x] Separate the in-place auth and the classic auth. Currently the filter is mucking up both. 