### PR TITLE
Demo a simple ui that displays errors

### DIFF
--- a/admin/class-client-example-admin.php
+++ b/admin/class-client-example-admin.php
@@ -10,6 +10,8 @@
  * @subpackage Client_Example/admin
  */
 
+require_once plugin_dir_path( __FILE__ ) . 'simple-ui/class-connection-simple-ui-admin.php';
+
 /**
  * The admin-specific functionality of the plugin.
  *
@@ -54,6 +56,8 @@ class Client_Example_Admin {
 		$this->version = $version;
 		$this->manager = $manager;
 
+		$this->connection_admin = new Connection_Admin( $manager );
+
 		add_action( 'admin_menu', array( $this, 'admin_menu' ) );
 		add_action( 'admin_post_register_site', array( $this, 'register_site' ) );
 		add_action( 'admin_post_connect_user', array( $this, 'connect_user' ) );
@@ -81,7 +85,31 @@ class Client_Example_Admin {
 			'',
 			4
 		);
+
+		$hook_iframe = add_submenu_page(
+			'client-example',
+			'Client Example - Simple UI - Iframe',
+			'Simple UI with Iframe',
+			'manage_options',
+			'client-example-simple-ui-iframe',
+			array( $this, 'generate_simple_ui_iframe_menu' ),
+		);
+
+		add_action( "load-$hook_iframe", array( $this->connection_admin, 'admin_page_load' ) );
+
+		$hook_calypso = add_submenu_page(
+			'client-example',
+			'Client Example - Simple UI - Calypso',
+			'Simple UI with Calypso',
+			'manage_options',
+			'client-example-simple-ui-calypso',
+			array( $this, 'generate_simple_ui_calypso_menu' ),
+		);
+
+		add_action( "load-$hook_calypso", array( $this->connection_admin, 'admin_page_load' ) );
 	}
+
+
 
 	/**
 	 * Register the stylesheets for the admin area.
@@ -134,6 +162,29 @@ class Client_Example_Admin {
 	public function generate_menu() {
 		require plugin_dir_path( __FILE__ ) . '/partials/client-example-admin-display.php';
 	}
+
+	/**
+	 * Generate the simple ui page with the auth iframe.
+	 */
+	 public function generate_simple_ui_iframe_menu() {
+		 global $is_safari;
+		 if ( $is_safari ) {
+			 add_filter( 'jetpack_use_iframe_authorization_flow', '__return_false' );
+		 } else {
+			 add_filter( 'jetpack_use_iframe_authorization_flow', '__return_true' );
+		 }
+
+		 require plugin_dir_path( __FILE__ ) . '/simple-ui/client-example-admin-simple-ui-display-iframe.php';
+	 }
+
+	 /**
+	  * Generate the simple ui page with original auth.
+	  */
+	  public function generate_simple_ui_calypso_menu() {
+
+		  add_filter( 'jetpack_use_iframe_authorization_flow', '__return_false' );
+		  require plugin_dir_path( __FILE__ ) . '/simple-ui/client-example-admin-simple-ui-display-calypso.php';
+	 }
 
 	/**
 	 * Registers the site using the connection package.

--- a/admin/css/client-example-admin.css
+++ b/admin/css/client-example-admin.css
@@ -2,3 +2,28 @@
  * All of the CSS for your admin-specific functionality should be
  * included in this file.
  */
+
+div.simple-ui {
+	background-color: #fff;
+	line-height: normal;
+	text-align: center;
+	padding: 25px 15px;
+	width: 50%;
+	min-width: 300px;
+	margin: 50px auto;
+	border: 1px solid #0071a1;
+	border-radius: 8px;
+}
+
+h1.simple-ui {
+	margin-top: 0px;
+}
+
+div.simple-ui .jp-jetpack-connect__iframe {
+	height: 250px;
+}
+
+.simple-ui #jetpack-logo__icon {
+	width: 100px;
+	height: 100px;
+}

--- a/admin/simple-ui/class-connection-simple-ui-admin.php
+++ b/admin/simple-ui/class-connection-simple-ui-admin.php
@@ -1,0 +1,144 @@
+<?php
+
+require_once plugin_dir_path( __FILE__ ) . 'connection-states/class-registering-state.php';
+require_once plugin_dir_path( __FILE__ ) . 'connection-states/class-authorizing-state.php';
+require_once plugin_dir_path( __FILE__ ) . 'connection-states/class-connected-state.php';
+require_once plugin_dir_path( __FILE__ ) . 'register-methods/class-register-iframe-method.php';
+require_once plugin_dir_path( __FILE__ ) . 'register-methods/class-register-calypso-method.php';
+
+class Connection_Admin {
+
+	public const AUTH_POST_ACTION            = 'authorize_user_simple_ui';
+	public const DISCONNECT_USER_POST_ACTION = 'disconnect_user_simple_ui';
+	public const DISCONNECT_SITE_POST_ACTION = 'disconnect_site_simple_ui';
+
+	private $registering_state;
+	private $authorizing_state;
+	private $connected_state;
+
+	private $register_iframe_method;
+	private $register_calypso_method;
+
+	public $manager;
+	private $connection_state;
+
+	private $error;
+
+	public function __construct( $manager ) {
+		$this->manager = $manager;
+
+		$this->registering_state  = new Registering_State( $this );
+		$this->authorizing_state  = new Authorizing_State( $this );
+		$this->connected_state   = new Connected_State();
+
+		$this->register_iframe_method  = new Register_Iframe_Method( $this );
+		$this->register_calypso_method = new Register_Calypso_Method( $this );
+
+		$this->set_state();
+		$this->set_up_post_request_handlers();
+	}
+
+	public function admin_page_load() {
+		if ( isset( $_GET['error'] ) ) {
+			$this->error = $_GET['error'];
+			add_action( 'admin_notices', array( $this, 'display_error_notice' ) );
+		}
+	}
+
+	private function set_up_post_request_handlers() {
+		add_action( 'admin_post_' . $this->register_iframe_method::POST_ACTION,
+			array( $this->register_iframe_method, 'register_site' ) );
+
+		add_action( 'admin_post_' . $this->register_calypso_method::POST_ACTION,
+			array( $this->register_calypso_method, 'register_site' ) );
+
+		add_action( 'admin_post_' . self::AUTH_POST_ACTION, array( $this, 'authorize_user' ) );
+		add_action( 'admin_post_' . self::DISCONNECT_USER_POST_ACTION, array( $this, 'disconnect_user' ) );
+		add_action( 'admin_post_' . self::DISCONNECT_SITE_POST_ACTION, array( $this, 'disconnect_site' ) );
+	}
+
+	private function set_state() {
+		$registered = $this->manager->get_access_token();
+		$authorized = $this->manager->is_user_connected();
+
+		if ( ! $registered ) {
+			$this->connection_state = $this->registering_state;
+
+		} elseif ( ! $authorized ) {
+			$this->connection_state = $this->authorizing_state;
+
+		} else {
+			$this->connection_state = $this->connected_state;
+		}
+	}
+
+	public function get_post_action() {
+		return $this->connection_state->get_post_action();
+	}
+
+	public function get_iframe_url() {
+		return $this->connection_state->get_iframe_url();
+	}
+
+	public function get_disconnect_user_action() {
+		return $this->connection_state->get_disconnect_user_action();
+	}
+
+	public function get_disconnect_site_action() {
+		return $this->connection_state->get_disconnect_site_action();
+	}
+
+	public function get_default_text() {
+		return $this->connection_state->get_default_text();
+	}
+
+	public function authorize_user() {
+		check_admin_referer( self::AUTH_POST_ACTION );
+		$result = $this->manager->connect_user();
+		$this->check_for_error_and_redirect( $result );
+	}
+
+	public function disconnect_user() {
+		check_admin_referer( self::DISCONNECT_USER_POST_ACTION );
+		$result = $this->manager->disconnect_user( get_current_user_id() );
+
+		if ( false === $result ) {
+			$result = new WP_Error(
+				'disconnect_user_failed',
+				'Could not disconnect the user. Either the user isn\'t connected,
+				 or the user is the master user.' );
+		}
+
+		$this->check_for_error_and_redirect( $result );
+	}
+
+	public function disconnect_site() {
+		check_admin_referer( self::DISCONNECT_SITE_POST_ACTION );
+		$this->manager->disconnect_site_wpcom();
+		$this->manager->delete_all_connection_tokens();
+		$this->check_for_error_and_redirect( null );
+	}
+
+	public function check_for_error_and_redirect( $result ){
+		if ( wp_get_referer() ) {
+			$redirect_url = wp_get_referer();
+
+			if (is_wp_error( $result ) ) {
+				error_log($result->get_error_message());
+				$redirect_url = add_query_arg( 'error', $result->get_error_message(), $redirect_url );
+			}
+			wp_safe_redirect( $redirect_url );
+
+		} else {
+			wp_safe_redirect( get_home_url() );
+		}
+	}
+
+	public function display_error_notice() {
+		?>
+	    <div class="notice notice-error">
+	        <p><?php echo $this->error; ?></p>
+	    </div>
+    <?php
+	}
+}

--- a/admin/simple-ui/client-example-admin-simple-ui-display-calypso.php
+++ b/admin/simple-ui/client-example-admin-simple-ui-display-calypso.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * Provide a admin area view with a simple ui for the plugin.
+ *
+ * This file is used to markup the admin-facing aspects of the plugin.
+ *
+ * @link       https://automattic.com
+ * @since      1.0.0
+ *
+ * @package    Client_Example
+ * @subpackage Client_Example/admin/partials
+ */
+
+?>
+
+<!-- This file should primarily consist of HTML with a little bit of PHP. -->
+<div class="simple-ui">
+
+	<h1 class="simple-ui">Jetpack Connection Package</h1>
+	<h2>Calypso Auth Flow</h2>
+	<br>
+
+	<?php
+		$text = $this->connection_admin->get_default_text();
+
+		// Show the post action button if a connection action needs to be completed.
+		if ( $this->connection_admin->get_post_action() ) {
+			$action = $this->connection_admin->get_post_action();
+			?>
+
+			<form action="/wp-admin/admin-post.php" method="post">
+				<input type="hidden" name="action" value="<?php echo $action; ?>">
+				<?php wp_nonce_field( $action ); ?>
+				<input type="submit" value="<?php echo $text; ?>" class="button button-primary">
+			</form>
+
+		<?php
+		// The connection is complete; show some text.
+		} else {
+		?>
+			<p><?php echo $text; ?></p>
+		<?php
+		}
+	//}
+
+	// Show the disconnect user button if possible.
+	if ( $this->connection_admin->get_disconnect_user_action() ) {
+		$action = $this->connection_admin->get_disconnect_user_action();
+		?>
+
+		<br>
+		<form action="/wp-admin/admin-post.php" method="post">
+			<input type="hidden" name="action" value="<?php echo $action; ?>">
+			<?php wp_nonce_field( $action ); ?>
+			<input type="submit" value="Disconnect User" class="button">
+		</form>
+
+	<?php
+	}
+
+	// Showt the disconnect site user button if possible.
+	if ( $this->connection_admin->get_disconnect_site_action() ) {
+		$action = $this->connection_admin->get_disconnect_site_action();
+		?>
+
+		<br>
+		<form action="/wp-admin/admin-post.php" method="post">
+			<input type="hidden" name="action" value="<?php echo $action; ?>">
+			<?php wp_nonce_field( $action ); ?>
+			<input type="submit" value="Disconnect Site" class="button">
+		</form>
+
+	<?php
+	}
+	?>
+
+</div>

--- a/admin/simple-ui/client-example-admin-simple-ui-display-iframe.php
+++ b/admin/simple-ui/client-example-admin-simple-ui-display-iframe.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Provide a admin area view with a simple ui for the plugin.
+ *
+ * This file is used to markup the admin-facing aspects of the plugin.
+ *
+ * @link       https://automattic.com
+ * @since      1.0.0
+ *
+ * @package    Client_Example
+ * @subpackage Client_Example/admin/partials
+ */
+
+?>
+
+<!-- This file should primarily consist of HTML with a little bit of PHP. -->
+<div class="simple-ui">
+
+	<h1 class="simple-ui">Jetpack Connection Package</h1>
+	<h2>Iframe Auth Flow</h2>
+	<br>
+
+	<?php
+	// Show the user authorization iframe if it's time for user authorization.
+	if ( $this->connection_admin->get_iframe_url() ) {
+		$iframe_url = $this->connection_admin->get_iframe_url();
+		?>
+
+		<iframe
+			class="jp-jetpack-connect__iframe"
+				style="
+					width: 100%;
+					background: white;
+					height: 250px;
+					padding-top: 30px;
+					"
+		/></iframe>
+
+		<script type="application/javascript">
+			jQuery( function( $ ) {
+				var authorize_url = decodeURIComponent( '<?php echo rawurlencode( (string) $iframe_url ); ?>' );
+				$( '.jp-jetpack-connect__iframe' ).attr( 'src', authorize_url );
+
+					window.addEventListener('message', (event) => {
+					if ( 'close' === event.data ) {
+						location.reload(true);
+					}
+				} );
+			} );
+		</script>
+
+	<?php
+	} else {
+		$text = $this->connection_admin->get_default_text();
+
+		// Show the post action button if registration needs to be completed.
+		if ( $this->connection_admin->get_post_action() ) {
+			$action = $this->connection_admin->get_post_action();
+			?>
+
+			<form action="/wp-admin/admin-post.php" method="post">
+				<input type="hidden" name="action" value="<?php echo $action; ?>">
+				<?php wp_nonce_field( $action ); ?>
+				<input type="submit" value="<?php echo $text; ?>" class="button button-primary">
+			</form>
+
+		<?php
+		// The connection is complete; show some text.
+		} else {
+		?>
+			<p><?php echo $text; ?></p>
+		<?php
+		}
+	}
+
+	// Show the disconnect user button if possible.
+	if ( $this->connection_admin->get_disconnect_user_action() ) {
+		$action = $this->connection_admin->get_disconnect_user_action();
+		?>
+
+		<br>
+		<form action="/wp-admin/admin-post.php" method="post">
+			<input type="hidden" name="action" value="<?php echo $action; ?>">
+			<?php wp_nonce_field( $action ); ?>
+			<input type="submit" value="Disconnect User" class="button">
+		</form>
+
+	<?php
+	}
+
+	// Showt the disconnect site user button if possible.
+	if ( $this->connection_admin->get_disconnect_site_action() ) {
+		$action = $this->connection_admin->get_disconnect_site_action();
+		?>
+
+		<br>
+		<form action="/wp-admin/admin-post.php" method="post">
+			<input type="hidden" name="action" value="<?php echo $action; ?>">
+			<?php wp_nonce_field( $action ); ?>
+			<input type="submit" value="Disconnect Site" class="button">
+		</form>
+
+	<?php
+	}
+	?>
+
+</div>

--- a/admin/simple-ui/connection-states/class-authorizing-state.php
+++ b/admin/simple-ui/connection-states/class-authorizing-state.php
@@ -1,0 +1,41 @@
+<?php
+
+require_once plugin_dir_path( __FILE__ ) . 'interface-connection-state.php';
+
+class Authorizing_State implements Connection_State {
+
+	private $connection_admin;
+
+	public function __construct( $connection_admin ) {
+		$this->connection_admin = $connection_admin;
+	}
+
+	public function get_post_action() {
+		if( apply_filters( 'jetpack_use_iframe_authorization_flow', false ) ) {
+			return null;
+		}
+
+		return Connection_Admin::AUTH_POST_ACTION;
+	}
+
+	public function get_iframe_url() {
+		if( apply_filters( 'jetpack_use_iframe_authorization_flow', false ) ) {
+			$auth_url = $this->connection_admin->manager->get_authorization_url( null );
+			return $auth_url;
+		}
+
+		return null;
+	}
+
+	public function get_disconnect_user_action() {
+		return null;
+	}
+
+	public function get_disconnect_site_action() {
+		return Connection_Admin::DISCONNECT_SITE_POST_ACTION;
+	}
+
+	public function get_default_text() {
+		return "Authorize User";
+	}
+}

--- a/admin/simple-ui/connection-states/class-connected-state.php
+++ b/admin/simple-ui/connection-states/class-connected-state.php
@@ -1,0 +1,26 @@
+<?php
+
+require_once plugin_dir_path( __FILE__ ) . 'interface-connection-state.php';
+
+class Connected_State implements Connection_State {
+
+	public function get_post_action() {
+		return null;
+	}
+
+	public function get_iframe_url() {
+		return null;
+	}
+
+	public function get_disconnect_user_action() {
+		return Connection_Admin::DISCONNECT_USER_POST_ACTION;
+	}
+
+	public function get_disconnect_site_action() {
+		return Connection_Admin::DISCONNECT_SITE_POST_ACTION;
+	}
+
+	public function get_default_text() {
+		return "The site is registered, and the user is authorized";
+	}
+}

--- a/admin/simple-ui/connection-states/class-registering-state.php
+++ b/admin/simple-ui/connection-states/class-registering-state.php
@@ -1,0 +1,30 @@
+<?php
+
+require_once plugin_dir_path( __FILE__ ) . 'interface-connection-state.php';
+
+class Registering_State implements Connection_State {
+
+	public function get_post_action() {
+		if( apply_filters( 'jetpack_use_iframe_authorization_flow', false ) ) {
+			return Register_Iframe_Method::POST_ACTION;
+		}
+
+		return Register_Calypso_Method::POST_ACTION;
+	}
+
+	public function get_iframe_url() {
+		return null;
+	}
+
+	public function get_disconnect_user_action() {
+		return null;
+	}
+
+	public function get_disconnect_site_action() {
+		return null;
+	}
+
+	public function get_default_text() {
+		return "Set Up Connection";
+	}
+}

--- a/admin/simple-ui/connection-states/interface-connection-state.php
+++ b/admin/simple-ui/connection-states/interface-connection-state.php
@@ -1,0 +1,14 @@
+<?php
+
+interface Connection_State {
+
+	public function get_post_action();
+
+	public function get_iframe_url();
+
+	public function get_disconnect_user_action();
+
+	public function get_disconnect_site_action();
+
+	public function get_default_text();
+}

--- a/admin/simple-ui/register-methods/class-register-calypso-method.php
+++ b/admin/simple-ui/register-methods/class-register-calypso-method.php
@@ -1,0 +1,24 @@
+<?php
+
+class Register_Calypso_Method {
+
+	public const POST_ACTION = 'register_site_calypso';
+
+	private $connection_admin;
+
+	public function __construct( $connection_admin ) {
+		$this->connection_admin = $connection_admin;
+	}
+
+	public function register_site() {
+		check_admin_referer( self::POST_ACTION );
+		$result = $this->connection_admin->manager->register();
+
+		if ( is_wp_error( $result ) ) {
+			$this->connection_admin->check_for_error_and_redirect( $result );
+		}
+
+		$result = $this->connection_admin->manager->connect_user();
+		$this->connection_admin->check_for_error_and_redirect( $result );
+	}
+}

--- a/admin/simple-ui/register-methods/class-register-iframe-method.php
+++ b/admin/simple-ui/register-methods/class-register-iframe-method.php
@@ -1,0 +1,18 @@
+<?php
+
+class Register_Iframe_Method {
+
+	public const POST_ACTION = 'register_site_iframe';
+
+	private $connection_admin;
+
+	public function __construct( $connection_admin ) {
+		$this->connection_admin = $connection_admin;
+	}
+
+	public function register_site() {
+		check_admin_referer( self::POST_ACTION );
+		$result = $this->connection_admin->manager->register();
+		$this->connection_admin->check_for_error_and_redirect( $result );
+	}
+}


### PR DESCRIPTION
This branch adds two new sub-menu pages to the plugin:

* Simple UI with Iframe: This proceeds through the connection flow using the iframe authorization.

* Simple UI with Calypso: This proceeds through the connection flow using the Calypso authorization. After registering, the user is immediately redirected to the account approval page. If a secondary admin wants to authorize, they will see an 'Authorize User' button.

If an error is generated, it's displayed in an admin notice.