### PR TITLE
Experiment/Do not merge: Jetpack Sync working as package

### DIFF
--- a/admin/class-client-example-admin.php
+++ b/admin/class-client-example-admin.php
@@ -92,7 +92,7 @@ class Client_Example_Admin {
 			'Simple UI with Iframe',
 			'manage_options',
 			'client-example-simple-ui-iframe',
-			array( $this, 'generate_simple_ui_iframe_menu' ),
+			array( $this, 'generate_simple_ui_iframe_menu' )
 		);
 
 		add_action( "load-$hook_iframe", array( $this->connection_admin, 'admin_page_load' ) );
@@ -103,7 +103,7 @@ class Client_Example_Admin {
 			'Simple UI with Calypso',
 			'manage_options',
 			'client-example-simple-ui-calypso',
-			array( $this, 'generate_simple_ui_calypso_menu' ),
+			array( $this, 'generate_simple_ui_calypso_menu' )
 		);
 
 		add_action( "load-$hook_calypso", array( $this->connection_admin, 'admin_page_load' ) );

--- a/client-example.php
+++ b/client-example.php
@@ -78,6 +78,101 @@ require plugin_dir_path( __FILE__ ) . 'includes/class-client-example.php';
  *
  * @since    1.0.0
  */
+
+function wp_startswith( $haystack, $needle ) {
+	return 0 === strpos( $haystack, $needle );
+}
+
+function jetpack_json_wrap( &$any, $seen_nodes = array() ) {
+	if ( is_object( $any ) ) {
+		$input        = get_object_vars( $any );
+		$input['__o'] = 1;
+	} else {
+		$input = &$any;
+	}
+
+	if ( is_array( $input ) ) {
+		$seen_nodes[] = &$any;
+
+		$return = array();
+
+		foreach ( $input as $k => &$v ) {
+			if ( ( is_array( $v ) || is_object( $v ) ) ) {
+				if ( in_array( $v, $seen_nodes, true ) ) {
+					continue;
+				}
+				$return[ $k ] = jetpack_json_wrap( $v, $seen_nodes );
+			} else {
+				$return[ $k ] = $v;
+			}
+		}
+
+		return $return;
+	}
+
+	return $any;
+}
+
+
+
+/**
+ * @param string $sandbox Sandbox domain
+ * @param string $url URL of request about to be made
+ * @param array  $headers Headers of request about to be made
+ * @return array [ 'url' => new URL, 'host' => new Host ]
+ */
+function jetpack_server_sandbox_request_parameters( $sandbox, $url, $headers ) {
+	$host = '';
+
+	$url_host = wp_parse_url( $url, PHP_URL_HOST );
+
+	switch ( $url_host ) {
+		case 'public-api.wordpress.com' :
+		case 'jetpack.wordpress.com' :
+		case 'jetpack.com' :
+		case 'dashboard.wordpress.com' :
+			$host = isset( $headers['Host'] ) ? $headers['Host'] : $url_host;
+			$url = preg_replace(
+				'@^(https?://)' . preg_quote( $url_host, '@' ) . '(?=[/?#].*|$)@',
+				'${1}' . $sandbox,
+				$url,
+				1
+			);
+	}
+
+	return compact( 'url', 'host' );
+}
+
+/**
+ * Modifies parameters of request in order to send the request to the
+ * server specified by `JETPACK__SANDBOX_DOMAIN`.
+ *
+ * Attached to the `requests-requests.before_request` filter.
+ * @param string &$url URL of request about to be made
+ * @param array  &$headers Headers of request about to be made
+ * @return void
+ */
+function jetpack_server_sandbox( &$url, &$headers ) {
+	if ( ! JETPACK__SANDBOX_DOMAIN ) {
+		return;
+	}
+
+	$original_url = $url;
+
+	$request_parameters = jetpack_server_sandbox_request_parameters( JETPACK__SANDBOX_DOMAIN, $url, $headers );
+	$url = $request_parameters['url'];
+	if ( $request_parameters['host'] ) {
+		$headers['Host'] = $request_parameters['host'];
+		if ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			error_log( sprintf( "SANDBOXING via '%s': '%s'", JETPACK__SANDBOX_DOMAIN, $original_url ) );
+		}
+	}
+}
+
+add_action( 'requests-requests.before_request', 'jetpack_server_sandbox', 10, 2 );
+
+
+
 function run_client_example() {
 
 	// Here we enable the Jetpack packages.
@@ -88,6 +183,28 @@ function run_client_example() {
 	$plugin = new Client_Example( $jetpack_connection_manager );
 
 	$plugin->run();
+
+	$config->ensure('sync');
+	\Automattic\Jetpack\Sync\Actions::init();
+
+
+	$queue = new Automattic\Jetpack\Sync\Queue('sync');
+
+	$post = wp_insert_post(['post_title' => 'asd'.microtime(true), 'post_content' => 'blarghhgh'.microtime(true)]);
+	$post = wp_insert_post(['post_title' => 'asd'.microtime(true), 'post_content' => 'blarghhgh'.microtime(true)]);
+	$post = wp_insert_post(['post_title' => 'asd'.microtime(true), 'post_content' => 'blarghhgh'.microtime(true)]);
+	$post = wp_insert_post(['post_title' => 'asd'.microtime(true), 'post_content' => 'blarghhgh'.microtime(true)]);
+	$post = wp_insert_post(['post_title' => 'asd'.microtime(true), 'post_content' => 'blarghhgh'.microtime(true)]);
+	$post = wp_insert_post(['post_title' => 'asd'.microtime(true), 'post_content' => 'blarghhgh'.microtime(true)]);
+	$post = wp_insert_post(['post_title' => 'asd'.microtime(true), 'post_content' => 'blarghhgh'.microtime(true)]);
+	$post = wp_insert_post(['post_title' => 'asd'.microtime(true), 'post_content' => 'blarghhgh'.microtime(true)]);
+	$post = wp_insert_post(['post_title' => 'asd'.microtime(true), 'post_content' => 'blarghhgh'.microtime(true)]);
+
+
+//	print_r($post);
+//
+	var_dump(count($queue->get_all()));
+	//$queue->flush_all();
 }
 
 add_action( 'plugins_loaded', 'run_client_example', 1 );

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,6 @@
         "automattic/jetpack-connection": "dev-master",
         "automattic/jetpack-tracking": "dev-master",
         "automattic/jetpack-config": "dev-master",
-        "automattic/jetpack-sync": "dev-master"
+        "automattic/jetpack-sync": "dev-master#80c4872fee73b0f7f853f1b514b29bcad636fa99"
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
 		"automattic/jetpack-autoloader": "dev-master",
         "automattic/jetpack-connection": "dev-master",
         "automattic/jetpack-tracking": "dev-master",
-        "automattic/jetpack-config": "dev-master"
+        "automattic/jetpack-config": "dev-master",
+        "automattic/jetpack-sync": "dev-master"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "053253d02ca265dcaa97377fc0a5b06a",
+    "content-hash": "afe9065d2ffe6d5adde1836d310e685e",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -48,12 +48,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-config.git",
-                "reference": "df7cfce4231fb50e8cd433a6ccf52e99a269c16c"
+                "reference": "4c6ea210ba8fa60f43f0d9eb725f70450f0ba210"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-config/zipball/df7cfce4231fb50e8cd433a6ccf52e99a269c16c",
-                "reference": "df7cfce4231fb50e8cd433a6ccf52e99a269c16c",
+                "url": "https://api.github.com/repos/Automattic/jetpack-config/zipball/4c6ea210ba8fa60f43f0d9eb725f70450f0ba210",
+                "reference": "4c6ea210ba8fa60f43f0d9eb725f70450f0ba210",
                 "shasum": ""
             },
             "type": "library",
@@ -67,7 +67,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Jetpack configuration package that initializes other packages and configures Jetpack's functionality. Can be used as a base for all variants of Jetpack package usage.",
-            "time": "2020-01-21T22:42:22+00:00"
+            "time": "2020-05-20T20:52:06+00:00"
         },
         {
             "name": "automattic/jetpack-connection",
@@ -75,12 +75,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-connection.git",
-                "reference": "21256f240360a5f9f687e9bb103182b3a695777d"
+                "reference": "ecc80bb6a61331ed71a7a1ee4d2749160259e99a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-connection/zipball/21256f240360a5f9f687e9bb103182b3a695777d",
-                "reference": "21256f240360a5f9f687e9bb103182b3a695777d",
+                "url": "https://api.github.com/repos/Automattic/jetpack-connection/zipball/ecc80bb6a61331ed71a7a1ee4d2749160259e99a",
+                "reference": "ecc80bb6a61331ed71a7a1ee4d2749160259e99a",
                 "shasum": ""
             },
             "require": {
@@ -107,7 +107,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Everything needed to connect to the Jetpack infrastructure",
-            "time": "2020-04-28T07:34:58+00:00"
+            "time": "2020-06-03T22:16:06+00:00"
         },
         {
             "name": "automattic/jetpack-constants",
@@ -146,12 +146,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-options.git",
-                "reference": "f3c6fc5e7eba07a8d1078aab643a64a5e656e5ab"
+                "reference": "546ab5685153e54c535a415562e5274509d52007"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-options/zipball/f3c6fc5e7eba07a8d1078aab643a64a5e656e5ab",
-                "reference": "f3c6fc5e7eba07a8d1078aab643a64a5e656e5ab",
+                "url": "https://api.github.com/repos/Automattic/jetpack-options/zipball/546ab5685153e54c535a415562e5274509d52007",
+                "reference": "546ab5685153e54c535a415562e5274509d52007",
                 "shasum": ""
             },
             "require": {
@@ -172,7 +172,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "A wrapper for wp-options to manage specific Jetpack options.",
-            "time": "2020-04-29T15:57:28+00:00"
+            "time": "2020-05-26T09:20:45+00:00"
         },
         {
             "name": "automattic/jetpack-roles",
@@ -236,6 +236,40 @@
             ],
             "description": "Used to retrieve information about the current status of Jetpack and the site overall.",
             "time": "2020-01-27T11:04:11+00:00"
+        },
+        {
+            "name": "automattic/jetpack-sync",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Automattic/jetpack-sync.git",
+                "reference": "0a03bfede037dc465fb382ebedaf32e62973fbd2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Automattic/jetpack-sync/zipball/0a03bfede037dc465fb382ebedaf32e62973fbd2",
+                "reference": "0a03bfede037dc465fb382ebedaf32e62973fbd2",
+                "shasum": ""
+            },
+            "require": {
+                "automattic/jetpack-connection": "@dev",
+                "automattic/jetpack-constants": "@dev",
+                "automattic/jetpack-options": "@dev",
+                "automattic/jetpack-roles": "@dev",
+                "automattic/jetpack-status": "@dev"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "description": "Everything needed to allow syncing to the WP.com infrastructure.",
+            "time": "2020-06-02T21:24:48+00:00"
         },
         {
             "name": "automattic/jetpack-terms-of-service",
@@ -317,7 +351,8 @@
         "automattic/jetpack-autoloader": 20,
         "automattic/jetpack-connection": 20,
         "automattic/jetpack-tracking": 20,
-        "automattic/jetpack-config": 20
+        "automattic/jetpack-config": 20,
+        "automattic/jetpack-sync": 20
     },
     "prefer-stable": false,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "afe9065d2ffe6d5adde1836d310e685e",
+    "content-hash": "f9dd9666ffe945c63fa468bf8fb58eab",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -146,12 +146,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-options.git",
-                "reference": "546ab5685153e54c535a415562e5274509d52007"
+                "reference": "eda3ee6b7548113429c0618846b883508bf3c9be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-options/zipball/546ab5685153e54c535a415562e5274509d52007",
-                "reference": "546ab5685153e54c535a415562e5274509d52007",
+                "url": "https://api.github.com/repos/Automattic/jetpack-options/zipball/eda3ee6b7548113429c0618846b883508bf3c9be",
+                "reference": "eda3ee6b7548113429c0618846b883508bf3c9be",
                 "shasum": ""
             },
             "require": {
@@ -172,7 +172,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "A wrapper for wp-options to manage specific Jetpack options.",
-            "time": "2020-05-26T09:20:45+00:00"
+            "time": "2020-06-10T21:49:54+00:00"
         },
         {
             "name": "automattic/jetpack-roles",
@@ -243,12 +243,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-sync.git",
-                "reference": "0a03bfede037dc465fb382ebedaf32e62973fbd2"
+                "reference": "80c4872fee73b0f7f853f1b514b29bcad636fa99"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-sync/zipball/0a03bfede037dc465fb382ebedaf32e62973fbd2",
-                "reference": "0a03bfede037dc465fb382ebedaf32e62973fbd2",
+                "url": "https://api.github.com/repos/Automattic/jetpack-sync/zipball/80c4872fee73b0f7f853f1b514b29bcad636fa99",
+                "reference": "80c4872fee73b0f7f853f1b514b29bcad636fa99",
                 "shasum": ""
             },
             "require": {
@@ -269,7 +269,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Everything needed to allow syncing to the WP.com infrastructure.",
-            "time": "2020-06-02T21:24:48+00:00"
+            "time": "2020-06-18T15:19:08+00:00"
         },
         {
             "name": "automattic/jetpack-terms-of-service",
@@ -313,12 +313,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-tracking.git",
-                "reference": "d337a8f4234c684e80a43ff9ad3051a46a1f35d6"
+                "reference": "09b036ee55d53f4d5acfa159f62ba2302e5aec7d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-tracking/zipball/d337a8f4234c684e80a43ff9ad3051a46a1f35d6",
-                "reference": "d337a8f4234c684e80a43ff9ad3051a46a1f35d6",
+                "url": "https://api.github.com/repos/Automattic/jetpack-tracking/zipball/09b036ee55d53f4d5acfa159f62ba2302e5aec7d",
+                "reference": "09b036ee55d53f4d5acfa159f62ba2302e5aec7d",
                 "shasum": ""
             },
             "require": {
@@ -341,7 +341,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Tracking for Jetpack",
-            "time": "2019-11-08T21:16:05+00:00"
+            "time": "2020-06-10T21:50:00+00:00"
         }
     ],
     "packages-dev": [],


### PR DESCRIPTION
Attempt at making Jetpack Sync work as a composer package.

Paired with this commit: https://github.com/Automattic/jetpack-sync/commit/80c4872fee73b0f7f853f1b514b29bcad636fa99

Context: p9dueE-1wm-p2

To test:

Checkout the branch
`composer update` 

There is a lot of debug enabled so most of the AJAX actions are going to fail, as the output will be polluted. 

To disable that, go into `client-example.php` and comment out everything after `$plugin->run()` in `run_client_example`.

This would stop Sync from initializing and throwing out debug messages.

* Log in into your test site
* Connect to WPCOM
* Uncomment what you commented above.
* Do several refreshes. 
* Monitor the debug output and see if you see output like this:

   ```
   string(24) " Syncing thingy =>>> RPC"
   bool(true)
   array(26) {
     [0]=>
     string(37) "jpsq_sync-1592493761.794594-896533-11"
     [........ same type of string......]
   ```

* This would indicate that Sync is running and WPCOM is accepting the events.