### PR TITLE
Config: Adjusting the plugin accordingly to the latest Jetpack Config API

### DIFF
--- a/client-example.php
+++ b/client-example.php
@@ -93,12 +93,18 @@ function run_client_example() {
 
 	// Here we enable the Jetpack packages.
 	$config = new Config();
-	$config->ensure(
-		'connection',
+	$config->setup(
 		array(
-			'slug'     => CLIENT_EXAMPLE_SLUG,
-			'name'     => CLIENT_EXAMPLE_NAME,
-			'url_info' => 'https://github.com/Automattic/client-example'
+			'connection' => array(
+				'deactivate_disconnect' => true,
+				'tos_link'              => true,
+			)
+		),
+		array(
+			'slug'        => CLIENT_EXAMPLE_SLUG,
+			'name'        => CLIENT_EXAMPLE_NAME,
+			'url_info'    => 'https://github.com/Automattic/client-example',
+			'plugin_file' => __FILE__,
 		)
 	);
 


### PR DESCRIPTION
Jetpack Config introduced a new way to configure packages: `$config->setup()`.

This PR:
1. Replaces the existing configuration with this new method.
2. Enables the auto-disconnect (soft/hard) when the Client Example plugin gets deactivated.

Requires Jetpack's branch `add/connection-disconnect-tos` to function.

See https://github.com/Automattic/jetpack/pull/17890 for more details.