### PR TITLE
Use Tokens::get_access_token instead of Manager::get_access_token.

### DIFF
--- a/admin/partials/client-example-admin-display.php
+++ b/admin/partials/client-example-admin-display.php
@@ -12,8 +12,10 @@
  * @subpackage Client_Example/admin/partials
  */
 
-$user_token = $this->manager->get_access_token( get_current_user_id() );
-$blog_token = $this->manager->get_access_token();
+use Automattic\Jetpack\Connection\Tokens;
+
+$user_token = ( new Tokens() )->get_access_token( get_current_user_id() );
+$blog_token = ( new Tokens() )->get_access_token();
 $is_plugin_enabled = $this->manager->is_plugin_enabled();
 add_filter( 'jetpack_use_iframe_authorization_flow', '__return_true' );
 $auth_url = $this->manager->get_authorization_url( null, admin_url( '?page=client-example' ) );

--- a/admin/simple-ui/class-connection-simple-ui-admin.php
+++ b/admin/simple-ui/class-connection-simple-ui-admin.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Connection\Tokens;
+
 require_once plugin_dir_path( __FILE__ ) . 'connection-states/class-registering-state.php';
 require_once plugin_dir_path( __FILE__ ) . 'connection-states/class-authorizing-state.php';
 require_once plugin_dir_path( __FILE__ ) . 'connection-states/class-connected-state.php';
@@ -64,7 +66,7 @@ class Connection_Admin {
 	}
 
 	private function set_state() {
-		$registered = $this->manager->get_access_token() && $this->manager->is_plugin_enabled();
+		$registered = ( new Tokens() )->get_access_token() && $this->manager->is_plugin_enabled();
 		$authorized = $this->manager->is_user_connected();
 
 		if ( ! $registered ) {

--- a/admin/simple-ui/register-methods/class-register-calypso-method.php
+++ b/admin/simple-ui/register-methods/class-register-calypso-method.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Connection\Tokens;
+
 class Register_Calypso_Method {
 
 	const POST_ACTION = 'register_site_calypso';
@@ -17,7 +19,7 @@ class Register_Calypso_Method {
 
 		$this->connection_admin->manager->enable_plugin();
 
-		if ( ! $this->connection_admin->manager->get_access_token() ) {
+		if ( ! ( new Tokens() )->get_access_token() ) {
 			$result = $this->connection_admin->manager->register();
 		}
 

--- a/admin/simple-ui/register-methods/class-register-iframe-method.php
+++ b/admin/simple-ui/register-methods/class-register-iframe-method.php
@@ -1,5 +1,7 @@
 <?php
 
+use Automattic\Jetpack\Connection\Tokens;
+
 class Register_Iframe_Method {
 
 	const POST_ACTION = 'register_site_iframe';
@@ -15,7 +17,7 @@ class Register_Iframe_Method {
 
 		$this->connection_admin->manager->enable_plugin();
 
-		if ( ! $this->connection_admin->manager->get_access_token() ) {
+		if ( ! ( new Tokens() )->get_access_token() ) {
 			$result = $this->connection_admin->manager->register();
 		}
 


### PR DESCRIPTION
The `Manager::get_access_token` method has been deprecated. Use the `Tokens::get_access_token` method instead.